### PR TITLE
Rubric display priority

### DIFF
--- a/peerreview/inc/datamanagers/pdoassignmentdatamanager.php
+++ b/peerreview/inc/datamanagers/pdoassignmentdatamanager.php
@@ -370,6 +370,11 @@ class PDOPeerReviewAssignmentDataManager extends AssignmentDataManager
         {
             $sh = $this->db->prepare("UPDATE peer_review_assignment_questions SET questionName=?, questionText=?, hidden=? WHERE questionID=?;");
             $sh->execute(array($question->name, $question->question, $question->hidden, $question->questionID));
+            if ($question->displayPriority!=0)
+	    {
+                $sh = $this->db->prepare("UPDATE peer_review_assignment_questions SET displayPriority=? WHERE questionID=?;");
+                $sh->execute(array($question->displayPriority,$question->questionID));
+	    }
         }
         //Now do the rest of the saving for each type
         switch(get_class($question))


### PR DESCRIPTION
… be set.

(before, displayPriority was ignored)

Now, if displayPriority is non-zero then it is set.  The reason we
do not set it when it is zero is that in the UI call to this function
(which does not set displayPriority), displayPriority is initialized
to zero.  It would be better if that code unset displayPriority and then
this function was modified to check whether displayPriority is set, rather
than non-zero.

With the caveat above, displayPriority can be effectively set with the API
using non-zero priorities.